### PR TITLE
added missing comma in the html_theme_options dict

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,7 +98,7 @@ or ``theme.conf`` for more details.
 
         # Set the color and the accent color
         'color_primary': 'blue',
-        'color_accent': 'light-blue'
+        'color_accent': 'light-blue',
 
         # Set the repo location to get a badge with stats
         'repo_url': 'https://github.com/project/project/',


### PR DESCRIPTION
Missing comma throws an error for impatient folks who blindly copy paste . Added it.