### PR TITLE
DOC: Use PyPI package in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Install via pip:
 
 .. code-block:: bash
 
-    $ pip install git+https://github.com/bashtage/sphinx-material
+    $ pip install sphinx-material
 
 or if you have the code checked out locally:
 


### PR DESCRIPTION
Is there a reason why the README still mentions the Github URL?

See https://github.com/spatialaudio/nbsphinx/pull/380.