### PR TITLE
Versions' menu on Read the Docs

### DIFF
--- a/sphinx_material/sphinx_material/static/stylesheets/application.css
+++ b/sphinx_material/sphinx_material/static/stylesheets/application.css
@@ -399,7 +399,7 @@ body,html{
 }
 body{
     position:relative;
-    font-size:.5rem
+    font-size:.85rem
 }
 hr{
     display:block;

--- a/sphinx_material/sphinx_material/static/stylesheets/application.css
+++ b/sphinx_material/sphinx_material/static/stylesheets/application.css
@@ -399,7 +399,7 @@ body,html{
 }
 body{
     position:relative;
-    font-size:.85rem
+    font-size:.5rem
 }
 hr{
     display:block;
@@ -1086,6 +1086,12 @@ html .md-nav__link[for=__toc],html .md-nav__link[for=__toc]+.md-nav__link:after,
 .md-sidebar__scrollwrap::-webkit-scrollbar-thumb:hover{
     background-color:#536dfe
 }
+
+.rst-versions {
+    /* Read the Docs' versions menu */
+    font-size: .85rem;
+}
+
 @-webkit-keyframes md-source__facts--done{
     0%{
         height:0


### PR DESCRIPTION
Hi! Thanks for this **great** theme!

I'm using this theme for my docs hosted at Read the Docs and I noticed that the flyout menu (versions' menu) added by Read the Docs at the bottom right renders with a very small font. See an example at https://sphinx-extensions.readthedocs.io/en/latest/

I found there is a [`body { font-size:.5rem; }`](https://github.com/bashtage/sphinx-material/blob/master/sphinx_material/sphinx_material/static/stylesheets/application.css#L402) CSS rule that produces this. However, it seems that rule is not used for the theme itself, since modifying it nothing changes, but the flyout menu.

This is how the menu looks **without this PR**,

![Screenshot_2020-04-05_20-13-00](https://user-images.githubusercontent.com/244656/78506501-27764800-777a-11ea-8afa-d47405ac57ff.png)

I'd be awesome if sphinx-material theme could be more compatible with the flyout Read the Docs adds on it.

Increasing this body font helps Sphinx Material theme to render nicely
the flyout menu (versions' menu) that Read the Docs adds.

This is how the menu looks **with this PR applied**,

![Screenshot_2020-04-05_20-14-58](https://user-images.githubusercontent.com/244656/78506591-ee8aa300-777a-11ea-8bec-0be80bb9e014.png)

You can check how Read the Docs' menu renders properly in Alabaster theme on `requests` documentation: https://requests.readthedocs.io/en/master/

> Please, feel free to make any change on this PR or suggestion. I do not have too much experience with CSS so it may affect other parts of the theme, but I just didn't find anything relevant.