### PR TITLE
Remove box-shadow from `.md-typeset code`

### DIFF
--- a/sphinx_material/sphinx_material/static/stylesheets/application.css
+++ b/sphinx_material/sphinx_material/static/stylesheets/application.css
@@ -194,6 +194,12 @@ code,kbd,pre{
     -webkit-box-decoration-break:clone;
     box-decoration-break:clone
 }
+.md-typeset code::before {
+  content: "\00a0";
+}
+.md-typeset code::after {
+  content: "\00a0";
+}
 .md-typeset h1 code,.md-typeset h2 code,.md-typeset h3 code,.md-typeset h4 code,.md-typeset h5 code,.md-typeset h6 code{
     margin:0;
     background-color:transparent;

--- a/sphinx_material/sphinx_material/static/stylesheets/application.css
+++ b/sphinx_material/sphinx_material/static/stylesheets/application.css
@@ -190,7 +190,6 @@ code,kbd,pre{
     margin:0 .29412em;
     padding:.07353em 0;
     border-radius:.1rem;
-    box-shadow:.29412em 0 0 hsla(0,0%,92.5%,.5),-.29412em 0 0 hsla(0,0%,92.5%,.5);
     word-break:break-word;
     -webkit-box-decoration-break:clone;
     box-decoration-break:clone


### PR DESCRIPTION
Removing it because it adds some extra spaces that affect the content that it's immediately before/after the text highlighted as code.

Example at: https://sphinx-extensions.readthedocs.io/en/latest/index.html

Without this PR, that page renders as:

![Screenshot_2020-04-07_16-08-42](https://user-images.githubusercontent.com/244656/78679089-0fbdd180-78ea-11ea-8ecc-d7317e0a6482.png)

(as you can notice, the `(` is affected by the box-shadow, and also the `,`. In the end, it seems it's only one thing highlighted when they are two)

With this PR, it renders as:

![Screenshot_2020-04-07_16-08-10](https://user-images.githubusercontent.com/244656/78679047-003e8880-78ea-11ea-8397-78d173e79c4f.png)
