### PR TITLE
Fixes #40 - Move requirements into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,17 @@ from setuptools import setup
 
 import versioneer
 
-with open("requirements.txt") as reqs:
-    REQUIREMENTS = [reqs.readlines()]
+REQUIREMENTS = [
+    'sphinx>=2.0',
+    'beautifulsoup4',
+    'python-slugify[unidecode]',
+    'css_html_js_minify',
+    'lxml',
+]
+
+REQUIREMENTS_DEV = [
+    'black==19.10b0',
+]
 
 setup(
     name="sphinx_material",
@@ -18,6 +27,9 @@ setup(
     include_package_data=True,
     python_requires=">=3.6",
     install_requires=REQUIREMENTS,
+    extras_require={
+        'dev': REQUIREMENTS_DEV,
+    },
     license="MIT",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Don't read them in. Add development requirements as extras for setuptools.