### PR TITLE
Provide entry_points for loading the theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,17 +42,7 @@ Add the following to your conf.py:
 
 .. code-block:: python
 
-    import sphinx_material
-
-     # Register the theme as an extension to generate a sitemap.xml
-    extensions.append('sphinx_material')
-    
-    # Choose the material theme
     html_theme = 'sphinx_material'
-    # Get the them path
-    html_theme_path = sphinx_material.html_theme_path()
-    # Register the required helpers for the html context
-    html_context = sphinx_material.get_html_context()
 
 
 There are a lot more ways to customize this theme, as this more comprehensive
@@ -60,13 +50,8 @@ example shows:
 
 .. code-block:: python
 
-    import sphinx_material
-
     # Required theme setup
-    extensions.append('sphinx_material')
     html_theme = 'sphinx_material'
-    html_theme_path = sphinx_material.html_theme_path()
-    html_context = sphinx_material.get_html_context()
 
     # Material theme options (see theme.conf for more information)
     html_theme_options = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,17 +43,7 @@ Update your ``conf.py`` with the required changes:
 
 .. code-block:: python
 
-    import sphinx_material
-
-     # Register the theme as an extension to generate a sitemap.xml
-    extensions.append('sphinx_material')
-
-    # Choose the material theme
     html_theme = 'sphinx_material'
-    # Get the them path
-    html_theme_path = sphinx_material.html_theme_path()
-    # Register the required helpers for the html context
-    html_context = sphinx_material.get_html_context()
 
 
 There are a lot more ways to customize this theme. See :ref:`Customization`
@@ -61,13 +51,7 @@ or ``theme.conf`` for more details.
 
 .. code-block:: python
 
-    import sphinx_material
-
-    # # Required theme setup
-    extensions.append('sphinx_material')
     html_theme = 'sphinx_material'
-    html_theme_path = sphinx_material.html_theme_path()
-    html_context = sphinx_material.get_html_context()
 
     # Material theme options (see theme.conf for more information)
     html_theme_options = {

--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,9 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
+    entry_points={
+        'sphinx.html_themes': [
+            'sphinx_material = sphinx_material',
+        ]
+    },
 )

--- a/sphinx_material/__init__.py
+++ b/sphinx_material/__init__.py
@@ -28,12 +28,16 @@ def setup(app):
     app.connect("build-finished", create_sitemap)
     app.connect("build-finished", reformat_pages)
     app.connect("build-finished", minify_css)
+    app.connect("builder-inited", update_html_context)
     manager = Manager()
     site_pages = manager.list()
     sitemap_links = manager.list()
     app.multiprocess_manager = manager
     app.sitemap_links = sitemap_links
     app.site_pages = site_pages
+    app.add_html_theme(
+        'sphinx_material',
+        os.path.join(html_theme_path()[0], 'sphinx_material'))
     return {
         "version": __version__,
         "parallel_read_safe": True,
@@ -131,6 +135,11 @@ def minify_css(app, exception):
             content.write(css)
     print()
     app.multiprocess_manager.shutdown()
+
+
+def update_html_context(app):
+    config = app.config
+    config.html_context = {**get_html_context(), **config.html_context}
 
 
 def html_theme_path():


### PR DESCRIPTION
This makes using the theme much easier, see updated usage examples.
Especially, it's not necessary anymore to add the module to extensions, but sitemap.xml is generated anyway. The `html_context` is also handled automatically.

See also https://github.com/guzzle/guzzle_sphinx_theme/pull/46.