### PR TITLE
Adding new theme option for minimal gdpr banner

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -35,6 +35,11 @@ Configuration Options
    Path to a touch icon, should be 152x152 or larger.
 ``google_analytics_account``
    Set to enable google analytics.
+``gdpr_banner_link``
+   Add a link to either an internal or external Privacy Policy page. If absent,
+   no banner is added. If present, minimal banner is added to footer of page.
+   If the 'x' (close) button on the banner is clicked, it remains closed for the
+   remained of the session.
 ``repo_url``
    Set the repo url for the link to appear.
 ``repo_name``

--- a/sphinx_material/sphinx_material/gdpr-banner.html
+++ b/sphinx_material/sphinx_material/gdpr-banner.html
@@ -1,0 +1,20 @@
+<div
+  class="privacy-banner"
+  style="border-top: 2px solid #ff910e; display: none;"
+>
+  <div class="banner-wrapper">
+    <p>
+      We use cookies to provide and improve our services. By using our site, you
+      consent to how we use cookies.
+      <a href="{{ theme_gdpr_banner }}" style="color: blue;">
+        <strong>Learn more</strong>
+      </a>
+    </p>
+    <button aria-label="Close" style="background: #ff910e;" type="button">
+      <span aria-hidden="true">x</span>
+    </button>
+  </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
+<script src="{{ pathto('_static/javascripts/gdpr-banner.js', 1) }}"></script>

--- a/sphinx_material/sphinx_material/layout.html
+++ b/sphinx_material/sphinx_material/layout.html
@@ -42,6 +42,11 @@
   <link rel="stylesheet" href="{{ pathto('_static/stylesheets/application.css', 1) }}"/>
   <link rel="stylesheet" href="{{ pathto('_static/stylesheets/application-palette.css', 1) }}"/>
   <link rel="stylesheet" href="{{ pathto('_static/stylesheets/application-fixes.css', 1) }}"/>
+
+  {% if theme_gdpr_banner_link %}
+    <link rel="stylesheet" href="{{ pathto('_static/stylesheets/gdpr-banner.css', 1) }}"/>
+  {% endif %}
+
   {% block fonticon %}
   <link rel="stylesheet" href="{{ pathto('_static/fonts/material-icons.css', 1) }}"/>
   {% endblock %}
@@ -191,5 +196,10 @@
   {%- block footer_scripts %}
   <script src="{{ pathto('_static/javascripts/application.js', 1) }}"></script>
   <script>app.initialize({version: "1.0.4", url: {base: ".."}})</script>
+
+  {% if theme_gdpr_banner_link %}
+    {% include "gdpr-banner.html" %}
+  {% endif %}
+
   {%- endblock %}
 {%- endblock %}

--- a/sphinx_material/sphinx_material/static/javascripts/gdpr-banner.js
+++ b/sphinx_material/sphinx_material/static/javascripts/gdpr-banner.js
@@ -1,0 +1,18 @@
+// Source repo: https://github.com/solodev/gdpr-banner
+// Banner Trigger if Not Closed
+if (!localStorage.bannerClosed) {
+    $('.privacy-banner').css('display', 'inherit');
+} else {
+    $('.privacy-banner').css('display', 'none');
+}
+$('.privacy-banner button').click(function() {
+    $('.privacy-banner').css('display', 'none');
+    localStorage.bannerClosed = 'true';
+});
+$('.banner-accept').click(function() {
+    $('.privacy-banner').css('display', 'none');
+    localStorage.bannerClosed = 'true';
+});
+if (navigator.userAgent.match(/Opera|OPR\//)) {
+    $('.privacy-banner').css('display', 'inherit');
+}

--- a/sphinx_material/sphinx_material/static/stylesheets/gdpr-banner.css
+++ b/sphinx_material/sphinx_material/static/stylesheets/gdpr-banner.css
@@ -1,0 +1,96 @@
+/*
+GDPR banner base css
+https://github.com/solodev/gdpr-banner/blob/master/gdpr-banner.css
+*/
+
+* {
+  box-sizing: border-box;
+}
+
+.privacy-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  max-width: 100%;
+  padding: 1rem 0.5rem;
+  background: #fff;
+  z-index: 1030;
+  color: #000;
+  font-size: 14px;
+  margin: 0;
+  display: none;
+}
+
+.banner-wrapper {
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  position: relative;
+  align-items: center;
+}
+
+.privacy-banner p {
+  margin: 0;
+  color: #000;
+  text-align: center;
+}
+
+.privacy-banner .banner-wrapper p {
+  padding-right: 3rem;
+}
+
+.privacy-banner a {
+  text-decoration: none;
+  margin: 20px auto 0 auto;
+  display: block;
+  max-width: 150px;
+}
+
+.privacy-banner a:hover {
+  text-decoration: underline;
+}
+
+.privacy-banner button {
+  position: absolute;
+  right: 5px;
+  top: calc(50% - 12.5px);
+  color: #fff;
+  outline: 0;
+  height: 25px;
+  width: 25px;
+  border: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  font-weight: 700;
+  border-radius: 50%;
+  text-align: center;
+  padding: 0;
+  line-height: 1;
+  background: #000;
+  cursor: pointer;
+}
+
+.banner-learn {
+  color: #000;
+}
+
+.banner-accept {
+  padding: 7px 15px;
+  color: #fff;
+  border-radius: 5px;
+  background: #000;
+}
+
+@media (min-width: 768px) {
+  .privacy-banner {
+    padding: 1.5rem 0.5rem;
+  }
+  .privacy-banner a {
+    display: inline-block;
+    margin: 0 10px;
+  }
+}

--- a/sphinx_material/sphinx_material/theme.conf
+++ b/sphinx_material/sphinx_material/theme.conf
@@ -28,6 +28,12 @@ disqus_comments_shortname =
 # Set to enable google analytics
 google_analytics_account =
 
+# GDPR banner link
+# Enter an endpoint link for the "Learn More" url for a Privacy Policy
+# Adds a small banner to the bottom of the page
+# Source: https://github.com/solodev/gdpr-banner
+gdpr_banner_link =
+
 # Repository integration
 # Set the repo url for the link to appear
 repo_url =


### PR DESCRIPTION
I was adding a minimal GDPR banner option to a fork of this theme, but realized it would make more sense to contribute it directly since it is something anyone can use (rather than merely style overrides).