### PR TITLE
Add an option to include or not the links to parents at nav bar

### DIFF
--- a/sphinx_material/sphinx_material/relbar.html
+++ b/sphinx_material/sphinx_material/relbar.html
@@ -11,9 +11,11 @@
             {% set localhref=pathto( item.href ) if item.internal else item.href|e %}
             <li class="md-tabs__item"><a href="{{ localhref|e }}" class="md-tabs__link">{{ item.title }}</a></li>
         {%- endfor %}
-        {%- for parent in parents %}
-          <li class="md-tabs__item"><a href="{{ parent.link|e }}" class="md-tabs__link">{{ parent.title }}</a></li>
-        {%- endfor %}
+        {%- if theme_nav_bar_display_parents %}
+          {%- for parent in parents %}
+            <li class="md-tabs__item"><a href="{{ parent.link|e }}" class="md-tabs__link">{{ parent.title }}</a></li>
+          {%- endfor %}
+        {%- endif %}
       </ul>
     </div>
   </nav>

--- a/sphinx_material/sphinx_material/theme.conf
+++ b/sphinx_material/sphinx_material/theme.conf
@@ -85,6 +85,9 @@ master_doc = True
 #   internal: Flag indicating to use pathto (bool)
 nav_links =
 
+# Include links of parent documents at navigation bar
+nav_bar_display_parents = True
+
 # Text to appear at the top of the home page in a "hero" div. Must be a
 # dict[str, str] of the form pagename: hero text, e.g., {'index': 'text on index'}
 heroes =


### PR DESCRIPTION
This PR introduces new theme config option 'nav_bar_display_parents'
that takes control of diplaying links to parent documents (in terms of
TOC) at navigation bar.

Changes to default behavior:

* nothing is changes, since the default value is True