### PR TITLE
add support for globaltoc_includeinternal, closes #86

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -50,6 +50,8 @@ Configuration Options
    If true, TOC entries that are not ancestors of the current page are collapsed.
 ``globaltoc_includehidden``
    If true, the global TOC tree will also contain hidden entries.
+``globaltoc_includeinternal``
+   If false, the global TOC tree will not contain internal section headings
 ``theme_color``
     The theme color for mobile browsers. Hex Color without the leading #.
 ``color_primary``

--- a/sphinx_material/sphinx_material/globaltoc.html
+++ b/sphinx_material/sphinx_material/globaltoc.html
@@ -3,6 +3,7 @@
   {% set toctree_nodes = derender_toc(toctree, False) %}
   <ul class="md-nav__list">
   {%- for item in toctree_nodes recursive %}
+    {% if (theme_globaltoc_includeinternal|tobool) or not ("#" in item.href and not item.href.endswith("#")) %}
     <li class="md-nav__item">
     {% if "caption" in item %}
       <span class="md-nav__link caption">{{ item.caption }}</span>
@@ -22,6 +23,7 @@
       {%- endif %}
     {% endif %}
     </li>
+    {% endif %}
   {%- endfor %}
   </ul>
   {# TODO: Fallback to toc? #}

--- a/sphinx_material/sphinx_material/theme.conf
+++ b/sphinx_material/sphinx_material/theme.conf
@@ -48,6 +48,8 @@ globaltoc_depth = 1
 globaltoc_collapse = true
 # If true, the global TOC tree will also contain hidden entries
 globaltoc_includehidden = true
+# If false, the global TOC tree will not contain internal section headings
+globaltoc_includeinternal = true
 
 # Colors
 # The theme color for mobile browsers. Hex color.


### PR DESCRIPTION
I realised I was overthinking the previous attempt (#87); this new version simply checks if the href contains "#" (and does not end with "#"), and omits those links in the global TOC.