### PR TITLE
Enable html_theme_options keys for a few hardcoded theme strings

### DIFF
--- a/sphinx_material/sphinx_material/layout.html
+++ b/sphinx_material/sphinx_material/layout.html
@@ -135,7 +135,7 @@
               <div class="md-flex__cell md-flex__cell--stretch md-footer-nav__title">
                 <span class="md-flex__ellipsis">
                   <span
-                      class="md-footer-nav__direction"> Previous </span> {{ prev.title }} </span>
+                      class="md-footer-nav__direction"> {{ theme_nav_previous_text }} </span> {{ prev.title }} </span>
               </div>
             </a>
           {% endif %}
@@ -145,7 +145,7 @@
                rel="next">
             <div class="md-flex__cell md-flex__cell--stretch md-footer-nav__title"><span
                 class="md-flex__ellipsis"> <span
-                class="md-footer-nav__direction"> Next </span> {{ next.title }} </span>
+                class="md-footer-nav__direction"> {{ theme_nav_next_text }} </span> {{ next.title }} </span>
             </div>
             <div class="md-flex__cell md-flex__cell--shrink"><i
                 class="md-icon md-icon--arrow-forward md-footer-nav__button"></i>

--- a/sphinx_material/sphinx_material/localtoc.html
+++ b/sphinx_material/sphinx_material/localtoc.html
@@ -1,7 +1,7 @@
 {% set toc_nodes = derender_toc(toc, True, pagename) if display_toc else [] %}
 <nav class="md-nav md-nav--secondary">
   {%- if display_toc and toc_nodes and sidebars and 'localtoc.html' in sidebars %}
-    <label class="md-nav__title" for="__toc">Contents</label>
+    <label class="md-nav__title" for="__toc">{{ theme_localtoc_label_text }}</label>
   {%- endif %}
   <ul class="md-nav__list" data-md-scrollfix="">
     {%- if display_toc and sidebars and 'localtoc.html' in sidebars %}

--- a/sphinx_material/sphinx_material/searchbox.html
+++ b/sphinx_material/sphinx_material/searchbox.html
@@ -3,7 +3,7 @@
   <label class="md-search__overlay" for="__search"></label>
   <div class="md-search__inner" role="search">
     <form class="md-search__form" action="{{ pathto('search') }}" method="get" name="search">
-      <input type="text" class="md-search__input" name="q" placeholder="Search"
+      <input type="text" class="md-search__input" name="q" placeholder="{{ theme_search_placeholder }}"
              autocapitalize="off" autocomplete="off" spellcheck="false"
              data-md-component="query" data-md-state="active">
       <label class="md-icon md-search__icon" for="__search"></label>

--- a/sphinx_material/sphinx_material/searchbox.html
+++ b/sphinx_material/sphinx_material/searchbox.html
@@ -3,7 +3,7 @@
   <label class="md-search__overlay" for="__search"></label>
   <div class="md-search__inner" role="search">
     <form class="md-search__form" action="{{ pathto('search') }}" method="get" name="search">
-      <input type="text" class="md-search__input" name="q" placeholder="{{ theme_search_placeholder }}"
+      <input type="text" class="md-search__input" name="q" placeholder="{{ theme_search_placeholder_text }}"
              autocapitalize="off" autocomplete="off" spellcheck="false"
              data-md-component="query" data-md-state="active">
       <label class="md-icon md-search__icon" for="__search"></label>

--- a/sphinx_material/sphinx_material/theme.conf
+++ b/sphinx_material/sphinx_material/theme.conf
@@ -48,6 +48,8 @@ globaltoc_depth = 1
 globaltoc_collapse = true
 # If true, the global TOC tree will also contain hidden entries
 globaltoc_includehidden = true
+# Label text for local TOC
+localtoc_label_text = "Contents"
 
 # Colors
 # The theme color for mobile browsers. Hex color.

--- a/sphinx_material/sphinx_material/theme.conf
+++ b/sphinx_material/sphinx_material/theme.conf
@@ -115,3 +115,6 @@ table_classes =
 # classes is set, **all** table classes are kept.
 # This is different to "table_classes", which only keeps the configured classes.
 table_no_strip =
+
+# Enable customizing the placeholder text of the search field
+search_placeholder = 'Search'

--- a/sphinx_material/sphinx_material/theme.conf
+++ b/sphinx_material/sphinx_material/theme.conf
@@ -86,6 +86,9 @@ master_doc = True
 #   title: The title to appear (str)
 #   internal: Flag indicating to use pathto (bool)
 nav_links =
+# Text for previous/next links
+nav_previous_text = "Previous"
+nav_next_text = "Next"
 
 # Text to appear at the top of the home page in a "hero" div. Must be a
 # dict[str, str] of the form pagename: hero text, e.g., {'index': 'text on index'}

--- a/sphinx_material/sphinx_material/theme.conf
+++ b/sphinx_material/sphinx_material/theme.conf
@@ -117,4 +117,4 @@ table_classes =
 table_no_strip =
 
 # Enable customizing the placeholder text of the search field
-search_placeholder = 'Search'
+search_placeholder_text = "Search"


### PR DESCRIPTION
Added support for `html_theme_options['search_placeholder']` in `conf.py` for overriding the search field placeholder text. This is necessary especially for international users.