### PR TITLE
Use logo_url instead of "logo", removed in Sphinx 6

### DIFF
--- a/sphinx_material/sphinx_material/header.html
+++ b/sphinx_material/sphinx_material/header.html
@@ -6,6 +6,9 @@
            class="md-header-nav__button md-logo">
           {% if theme_logo_icon|e %}
             <i class="md-icon">{{ theme_logo_icon }}</i>
+          {% elif logo_url %}
+              <img src="{{ logo_url }}" height="26"
+                   alt="{{ shorttitle|striptags|e }} logo">
           {% elif logo %}
               <img src="{{ pathto('_static/' ~ logo, 1) }}" height="26"
                    alt="{{ shorttitle|striptags|e }} logo">

--- a/sphinx_material/sphinx_material/sidebar.html
+++ b/sphinx_material/sphinx_material/sidebar.html
@@ -3,6 +3,8 @@
     <a href="{{ pathto(master_doc)|e }}" title="{{ docstitle|striptags|e }}" class="md-nav__button md-logo">
       {% if theme_logo_icon %}
         <i class="md-icon">{{ theme_logo_icon }}</i>
+      {% elif logo_url %}
+        <img src="{{ logo_url }}" alt="{{ html_title }} logo" width="48" height="48">
       {% else %}
         <img src="{{ pathto('_static/' ~ logo, 1) }}" alt="{{ html_title }} logo" width="48" height="48">
       {% endif %}


### PR DESCRIPTION
In commit sphinx-doc/sphinx@ac0fc4b78173 (`Remove more deprecated items in Sphinx 6.0 (#10562)`), Sphinx removed the deprecated variables `logo` and `favicon`, in favour of `logo_url` and `favicon_url`, respectively. As a consequence, including the logo defined in `html_logo` no longer works when the sphinx_material theme is used with Sphinx >= 6.

Let's use `logo_url` if available in header.html. We also use it in sidebar.html, although this one doesn't matter much because CSS class `md-nav__button` gets a `display:none` in application.css.